### PR TITLE
Fix ERC721 test interchain gas payments

### DIFF
--- a/test/erc20.test.ts
+++ b/test/erc20.test.ts
@@ -59,7 +59,7 @@ for (const variant of [
     let localTokenConfig: TokenConfig = tokenConfig;
     let local: HypERC20 | HypERC20Collateral | HypNative;
     let remote: HypERC20 | HypERC20Collateral;
-    let gas: BigNumber;
+    let interchainGasPayment: BigNumber;
 
     beforeEach(async () => {
       [owner, recipient] = await ethers.getSigners();
@@ -101,10 +101,10 @@ for (const variant of [
       contracts = await deployer.deploy();
       local = contracts[localChain].router as HypERC20;
 
-      gas = await local.quoteGasPayment(remoteDomain);
+      interchainGasPayment = await local.quoteGasPayment(remoteDomain);
 
       if (variant === TokenType.native) {
-        gas = gas.add(amount);
+        interchainGasPayment = interchainGasPayment.add(amount);
       }
 
       if (variant === TokenType.collateral) {
@@ -165,7 +165,7 @@ for (const variant of [
           remoteDomain,
           utils.addressToBytes32(remote.address),
           amount,
-          { value: gas },
+          { value: interchainGasPayment },
         );
       }
       const message = `${utils.addressToBytes32(
@@ -191,7 +191,7 @@ for (const variant of [
         utils.addressToBytes32(recipient.address),
         amount,
         {
-          value: gas,
+          value: interchainGasPayment,
         },
       );
 
@@ -227,7 +227,7 @@ for (const variant of [
           remoteDomain,
           utils.addressToBytes32(recipient.address),
           amount,
-          { value: gas },
+          { value: interchainGasPayment },
         ),
       ).to.emit(interchainGasPaymaster, 'GasPayment');
     });
@@ -244,7 +244,8 @@ for (const variant of [
         }
         return '';
       };
-      const value = variant === TokenType.native ? amount - 1 : gas;
+      const value =
+        variant === TokenType.native ? amount - 1 : interchainGasPayment;
       await expect(
         local
           .connect(recipient)
@@ -263,7 +264,7 @@ for (const variant of [
           remoteDomain,
           utils.addressToBytes32(recipient.address),
           amount,
-          { value: gas },
+          { value: interchainGasPayment },
         ),
       )
         .to.emit(local, 'SentTransferRemote')

--- a/test/erc721.test.ts
+++ b/test/erc721.test.ts
@@ -75,7 +75,7 @@ for (const withCollateral of [true, false]) {
       let contracts: ChainMap<HypERC721Contracts>;
       let local: HypERC721 | HypERC721Collateral | HypERC721URICollateral;
       let remote: HypERC721 | HypERC721Collateral | HypERC721URIStorage;
-      let gas: BigNumberish;
+      let interchainGasPayment: BigNumberish;
 
       beforeEach(async () => {
         [owner, recipient] = await ethers.getSigners();
@@ -125,7 +125,7 @@ for (const withCollateral of [true, false]) {
           await erc721!.approve(local.address, tokenId3);
           await erc721!.approve(local.address, tokenId4);
         }
-        gas = await local.destinationGas(remoteDomain);
+        interchainGasPayment = await local.quoteGasPayment(remoteDomain);
 
         remote = contracts[remoteChain].router;
       });
@@ -186,7 +186,7 @@ for (const withCollateral of [true, false]) {
             remoteDomain,
             utils.addressToBytes32(recipient.address),
             invalidTokenId,
-            { value: gas },
+            { value: interchainGasPayment },
           ),
         ).to.be.revertedWith('ERC721: invalid token ID');
       });
@@ -196,7 +196,7 @@ for (const withCollateral of [true, false]) {
           remoteDomain,
           utils.addressToBytes32(recipient.address),
           tokenId2,
-          { value: gas },
+          { value: interchainGasPayment },
         );
 
         await expectBalance(local, recipient, 0);
@@ -221,7 +221,7 @@ for (const withCollateral of [true, false]) {
             remoteDomain,
             utils.addressToBytes32(recipient.address),
             tokenId2,
-            { value: gas },
+            { value: interchainGasPayment },
           );
 
           await expect(remoteUri.tokenURI(tokenId2)).to.be.revertedWith('');
@@ -245,7 +245,7 @@ for (const withCollateral of [true, false]) {
               remoteDomain,
               utils.addressToBytes32(recipient.address),
               tokenId2,
-              { value: gas },
+              { value: interchainGasPayment },
             ),
         ).to.be.revertedWith(revertReason);
       });
@@ -293,7 +293,7 @@ for (const withCollateral of [true, false]) {
             utils.addressToBytes32(recipient.address),
             tokenId3,
             {
-              value: gas,
+              value: interchainGasPayment,
             },
           ),
         ).to.emit(interchainGasPaymaster, 'GasPayment');
@@ -305,7 +305,7 @@ for (const withCollateral of [true, false]) {
             remoteDomain,
             utils.addressToBytes32(recipient.address),
             tokenId4,
-            { value: gas },
+            { value: interchainGasPayment },
           ),
         )
           .to.emit(local, 'SentTransferRemote')


### PR DESCRIPTION
In https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/1765, there are some changes to the IGP that revealed the ERC-721 test was incorrectly paying for interchain gas -- it was calling `destinationGas` instead of `quoteGasPayment`. This fixes that and renames `gas` -> `interchainGasPayment` for extra clarity