### PR TITLE
Fixed unprovided argument and too many arguments

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -72,8 +72,8 @@ async function deployWarpRoute() {
   multiProvider.setSharedSigner(signer)
 
   console.log('Starting deployments');
-  const deployer = new HypERC20Deployer(multiProvider, tokenConfigs, undefined);
-  await deployer.deploy();
+  const deployer = new HypERC20Deployer(multiProvider);
+  await deployer.deploy(tokenConfigs);
 
   console.log('Deployments successful. Deployed contracts:');
   // @ts-ignore


### PR DESCRIPTION
Fixed unprovided argument for deployer.deploy
Fixed too many arguments for HypERC20Deployer
The two problems above prevented the warp route from deploying according to the instructions provided in the docs.