### PR TITLE
Update package version to 1.3.2-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hyperlane-xyz/hyperlane-token",
   "description": "A template for interchain ERC20 and ERC721 tokens using Hyperlane",
-  "version": "1.3.2",
+  "version": "1.3.2-beta",
   "dependencies": {
     "@hyperlane-xyz/core": "1.3.2",
     "@hyperlane-xyz/sdk": "1.3.2",


### PR DESCRIPTION
There was a hiccup in publishing 1.3.2 in which dist was not regenerated.

Latest was renamed to 1.3.2-beta