### PR TITLE
Use configured collateral metadata if present, instead of fetching on chain

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,7 @@ export type SyntheticConfig = TokenMetadata & {
 export type CollateralConfig = {
   type: TokenType.collateral | TokenType.collateralUri;
   token: string;
-};
+} & Partial<ERC20Metadata>;
 export type NativeConfig = {
   type: TokenType.native;
 };

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -96,18 +96,20 @@ export class HypERC20Deployer extends GasRouterDeployer<
       totalSupply: 0,
     };
 
-    if (metadata.name !== undefined && metadata.symbol !== undefined && metadata.decimals !== undefined) {
+    if (metadata.name && metadata.symbol && metadata.decimals !== undefined && metadata.decimals !== null) {
       return metadata as ERC20Metadata;
     }
-
     const fetchedMetadata = await HypERC20Deployer.fetchMetadata(
       this.multiProvider.getProvider(chain),
       config,
     );
-
+    // Filter out undefined values
+    const definedConfigMetadata = Object.fromEntries(
+      Object.entries(metadata).filter(([_, v]) => v !== undefined)
+    );
     return {
       ...fetchedMetadata,
-      ...metadata,
+      ...definedConfigMetadata,
     } as ERC20Metadata;
   }
 

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -89,7 +89,7 @@ export class HypERC20Deployer extends GasRouterDeployer<
     chain: ChainName,
     config: CollateralConfig,
   ): Promise<ERC20Metadata> {
-    let metadata = {
+    const metadata = {
       name: config.name,
       symbol: config.symbol,
       decimals: config.decimals,


### PR DESCRIPTION
For a collateral token that lives on sealevel, we can't get the metadata on-chain. This change will use configured token metadata for a collateral token if it's present, and will fetch any missing pieces on-chain.